### PR TITLE
fix: remove stray text from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,3 @@
 - [Python](https://github.com/noFlowWater/my-project/tree/python)
 
 
-test35


### PR DESCRIPTION
## Summary
- remove stray `test35` line from README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68467f43bc808320a8710a57a5dd5de4